### PR TITLE
adjusting the ffmpeg_burnins lib to not parse a system font

### DIFF
--- a/contrib/adapters/tests/test_burnins.py
+++ b/contrib/adapters/tests/test_burnins.py
@@ -116,16 +116,18 @@ SAMPLE_DATA = """{
 WITH_BG = ('ffmpeg -loglevel panic -i TEST.MOV -vf "drawtext=text='
            '\'Top Center\':x=w/2-tw/2:y=0:fontcolor=white@1.0:fontsize'
            '=48:fontfile=/System/Library/Fonts/Menlo.ttc:box=1:boxbord'
-           'erw=5:boxcolor=black@1.0,drawtext=text='
-           r'\'%{eif\:n+101\:d}\':x=75:y=0:fontcolor=white@1.0:fontsize'
-           '=48:fontfile=/System/Library/Fonts/Menlo.ttc:box=1:boxbord'
-           'erw=5:boxcolor=black@1.0" TEST.MOV')
+           'erw=5:boxcolor=black@1.0,drawtext=text=\''
+           r'%{eif\:n+101\:d}'
+           '\':x=75:y=0:fontcolor=white@1.0:fontsize=48:fontfile=/Syst'
+           'em/Library/Fonts/Menlo.ttc:box=1:boxborderw=5:boxcolor=bla'
+           'ck@1.0" TEST.MOV')
 
 WITHOUT_BG = ('ffmpeg -loglevel panic -i TEST.MOV -vf "drawtext=text='
               '\'Top Center\':x=w/2-tw/2:y=0:fontcolor=white@1.0:fontsize'
-              '=48:fontfile=/System/Library/Fonts/Menlo.ttc,drawtext=text='
-              r'\'%{eif\:n+101\:d}\':x=75:y=0:fontcolor=white@1.0:fontsize'
-              '=48:fontfile=/System/Library/Fonts/Menlo.ttc" TEST.MOV')
+              '=48:fontfile=/System/Library/Fonts/Menlo.ttc,drawtext=text=\''
+              r'%{eif\:n+101\:d}'
+              '\':x=75:y=0:fontcolor=white@1.0:fontsize=48:fontfile=/System'
+              '/Library/Fonts/Menlo.ttc" TEST.MOV')
 
 
 class FFMPEGBurninsTest(unittest.TestCase):


### PR DESCRIPTION
Only happens when using RIGHT alignments

this should get around the test case issues